### PR TITLE
Added prop-types and react-router so that CircleCI builds pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,17 @@
     "husky": "^0.13.3",
     "lint-staged": "^3.4.0",
     "prettier": "^1.2.2",
-    "react-addons-test-utils": "^15.5.1",
     "react-test-renderer": "^15.5.4"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-addons-css-transition-group": "^15.5.2",
     "react-addons-transition-group": "^15.5.2",
     "react-dom": "^15.5.4",
     "react-md": "^1.0.11",
     "react-redux": "^5.0.3",
+    "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "react-router-redux": "next",
     "redux": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5024,7 +5024,7 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -5116,13 +5116,6 @@ react-addons-css-transition-group@^15.5.2:
 "react-addons-shallow-compare@^0.14.0 || ^15.0.0":
   version "15.5.2"
   resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.5.2.tgz#7cb0ee7acc8d7c93fcc202df0bf47ba916a7bdad"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
-react-addons-test-utils@^15.5.1:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"


### PR DESCRIPTION
Also removes `react-addons-test-utils` since those are deprecated and available in `react-dom` now.

![](https://media.giphy.com/media/HLOaKrmaomOnm/giphy.gif)